### PR TITLE
Pr4 modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .cache
 .classpath
 .project
+.idea/
+project/project/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ target/
 .classpath
 .project
 .idea/
-project/project/

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object BuildDef extends Build {
 		//project settings
 		.settings(
 			organization := "com.github.thangiee",
-			version := "1.2",
+			version := "1.2.1",
 			scalaVersion := "2.11.8",
 			libraryDependencies += scalaTest % "test",
 			scalacOptions in (Compile, doc) += "-implicits",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,5 @@
 import sbt._
 import Keys._
-import bintray.BintrayPlugin.autoImport._
 
 object BuildDef extends Build {
 
@@ -9,14 +8,46 @@ object BuildDef extends Build {
 	lazy val scalaFRP = Project("scala-frp", file("."))
 		//project settings
 		.settings(
-			organization := "com.github.thangiee",
-			version := "1.2.1",
+			organization := "io.dylemma",
+			version := "1.2",
 			scalaVersion := "2.11.8",
+			crossScalaVersions := Seq("2.10.6", "2.11.8"),
 			libraryDependencies += scalaTest % "test",
-			scalacOptions in (Compile, doc) += "-implicits",
-			publishMavenStyle := true,
-			resolvers += Resolver.jcenterRepo,
-      licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-      bintrayVcsUrl := Some("https://github.com/Thangiee/scala.frp")
+			scalacOptions in (Compile, doc) += "-implicits"
 		)
+	  .settings(publishingSettings: _*)
+
+	lazy val publishingSettings = Seq(
+		publishMavenStyle := true,
+		publishTo := {
+			val nexus = "https://oss.sonatype.org/"
+			if(isSnapshot.value)
+				Some("snapshots" at nexus + "content/repositories/snapshots")
+			else
+				Some("releases" at nexus + "service/local/staging/deploy/maven2")
+		},
+		publishArtifact in Test := false,
+		pomIncludeRepository := { _ => false },
+		pomExtra := (
+			<url>https://github.com/dylemma/scala.frp</url>
+				<licenses>
+					<license>
+						<name>MIT License</name>
+						<url>http://opensource.org/licenses/mit-license.php</url>
+						<distribution>repo</distribution>
+					</license>
+				</licenses>
+				<scm>
+					<url>git@github.com:dylemma/scala.frp.git</url>
+					<connection>scm:git:git@github.com:dylemma/scala.frp.git</connection>
+				</scm>
+				<developers>
+					<developer>
+						<id>dylemma</id>
+						<name>Dylan Halperin</name>
+						<url>http://dylemma.io/</url>
+					</developer>
+				</developers>
+			)
+	)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,6 @@
 import sbt._
 import Keys._
+import bintray.BintrayPlugin.autoImport._
 
 object BuildDef extends Build {
 
@@ -8,46 +9,14 @@ object BuildDef extends Build {
 	lazy val scalaFRP = Project("scala-frp", file("."))
 		//project settings
 		.settings(
-			organization := "io.dylemma",
+			organization := "com.github.thangiee",
 			version := "1.2",
 			scalaVersion := "2.11.8",
 			libraryDependencies += scalaTest % "test",
-			scalacOptions in (Compile, doc) += "-implicits"
-		)
-		//publishing settings
-		.settings(
+			scalacOptions in (Compile, doc) += "-implicits",
 			publishMavenStyle := true,
-			publishArtifact in Test := false,
-			pomIncludeRepository := { _ => false },
-			pomExtra := pomExtraXml,
-			publishTo <<= version { (v: String) =>
-				val nexus = "https://oss.sonatype.org/"
-				if(v.trim.endsWith("SNAPSHOT"))
-					Some("snapshots" at nexus + "content/repositories/snapshots")
-				else
-					Some("releases" at nexus + "service/local/staging/deploy/maven2")
-			}
+			resolvers += Resolver.jcenterRepo,
+      licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
+      bintrayVcsUrl := Some("https://github.com/Thangiee/scala.frp")
 		)
-
-	lazy val pomExtraXml = (
-		<url>https://github.com/dylemma/scala.frp</url>
-		<licenses>
-			<license>
-				<name>MIT License</name>
-				<url>http://opensource.org/licenses/mit-license.php</url>
-				<distribution>repo</distribution>
-			</license>
-		</licenses>
-		<scm>
-			<url>git@github.com:dylemma/scala.frp.git</url>
-			<connection>scm:git:git@github.com:dylemma/scala.frp.git</connection>
-		</scm>
-		<developers>
-			<developer>
-				<id>dylemma</id>
-				<name>Dylan Halperin</name>
-				<url>http://dylemma.io/</url>
-			</developer>
-		</developers>
-	)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,14 +3,14 @@ import Keys._
 
 object BuildDef extends Build {
 
-	val scalaTest = "org.scalatest" %% "scalatest" % "1.9.1"
+	val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6"
 
 	lazy val scalaFRP = Project("scala-frp", file("."))
 		//project settings
 		.settings(
 			organization := "io.dylemma",
-			version := "1.1",
-			scalaVersion := "2.10.3",
+			version := "1.2",
+			scalaVersion := "2.11.8",
 			libraryDependencies += scalaTest % "test",
 			scalacOptions in (Compile, doc) += "-implicits"
 		)
@@ -28,7 +28,7 @@ object BuildDef extends Build {
 					Some("releases" at nexus + "service/local/staging/deploy/maven2")
 			}
 		)
-		
+
 	lazy val pomExtraXml = (
 		<url>https://github.com/dylemma/scala.frp</url>
 		<licenses>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/readme.md
+++ b/readme.md
@@ -1,25 +1,18 @@
 Scala FRP
 =========
 
-This library replaces the idea of `Publishers` and `Subscribers` with `EventStreams`. An `EventStream`
-can be treated like a collection of events; it can be transformed similarly to any other Scala collection, and
-instead of needing to call `publisher.addEventListener(new EventListener(){...})`, you simply call `eventStream.foreach{...}`
+This library replaces the idea of `Publishers` and `Subscribers` with `EventStreams`. An `EventStream` can be treated like a collection of events; it can be transformed similarly to any other Scala collection, and instead of needing to call `publisher.addEventListener(new EventListener(){...})`, you simply call `eventStream.foreach{...}`
 
 ###Background
 
-Scala FRP (stands for **F**unctional **R**eactive **P**rogramming) is a library inspired by
-[Ingo Maier's](http://lampwww.epfl.ch/~imaier/) paper, [Deprecating the Observer Pattern](http://lampwww.epfl.ch/~imaier/pub/DeprecatingObserversTR2010.pdf).
-Ingo Maier made an implementation of his "scala.react" framework which is available [on Github](https://github.com/ingoem/scala-react)
-in its original form. I also made a version of the same library that works with SBT to manage its dependencies,
-available [here](https://github.com/dylemma/scala.react).
+Scala FRP (stands for **F**unctional **R**eactive **P**rogramming) is a library inspired by [Ingo Maier's](http://lampwww.epfl.ch/~imaier/) paper, [Deprecating the Observer Pattern](http://lampwww.epfl.ch/~imaier/pub/DeprecatingObserversTR2010.pdf). Ingo Maier made an implementation of his "scala.react" framework which is available [on Github](https://github.com/ingoem/scala-react) in its original form. I also made a version of the same library that works with SBT to manage its dependencies, available [here](https://github.com/dylemma/scala.react).
 
 ###Getting it
 
-Scala FRP is built for Scala 2.11.8; as long as your project is using Scala 2.10, you can simply add the following to your sbt settings:
+Add the following to your `build.sbt` file:
 
 ```
-resolvers += "jcenter" at "https://jcenter.bintray.com/"
-libraryDependencies += "com.github.thangiee" %% "scala-frp" % "1.2"
+libraryDependencies += "io.dylemma" %% "scala-frp" % "1.2"
 ```
 
 ###Example Usage

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,26 @@
 Scala FRP
 =========
 
-This library replaces the idea of `Publishers` and `Subscribers` with `EventStreams`. An `EventStream` can be treated like a collection of events; it can be transformed similarly to any other Scala collection, and instead of needing to call `publisher.addEventListener(new EventListener(){...})`, you simply call `eventStream.foreach{...}`
+This library replaces the idea of `Publishers` and `Subscribers` with `EventStreams`. An `EventStream`
+can be treated like a collection of events; it can be transformed similarly to any other Scala collection, and
+instead of needing to call `publisher.addEventListener(new EventListener(){...})`, you simply call `eventStream.foreach{...}`
 
 ###Background
 
-Scala FRP (stands for **F**unctional **R**eactive **P**rogramming) is a library inspired by [Ingo Maier's](http://lampwww.epfl.ch/~imaier/) paper, [Deprecating the Observer Pattern](http://lampwww.epfl.ch/~imaier/pub/DeprecatingObserversTR2010.pdf). Ingo Maier made an implementation of his "scala.react" framework which is available [on Github](https://github.com/ingoem/scala-react) in its original form. I also made a version of the same library that works with SBT to manage its dependencies, available [here](https://github.com/dylemma/scala.react).
+Scala FRP (stands for **F**unctional **R**eactive **P**rogramming) is a library inspired by
+[Ingo Maier's](http://lampwww.epfl.ch/~imaier/) paper, [Deprecating the Observer Pattern](http://lampwww.epfl.ch/~imaier/pub/DeprecatingObserversTR2010.pdf).
+Ingo Maier made an implementation of his "scala.react" framework which is available [on Github](https://github.com/ingoem/scala-react)
+in its original form. I also made a version of the same library that works with SBT to manage its dependencies,
+available [here](https://github.com/dylemma/scala.react).
 
 ###Getting it
 
-Scala FRP is built for Scala 2.10.3; as long as your project is using Scala 2.10, you can simply add the following to your sbt settings:
+Scala FRP is built for Scala 2.11.8; as long as your project is using Scala 2.10, you can simply add the following to your sbt settings:
 
-	libraryDependencies += "io.dylemma" %% "scala-frp" % "1.1"
+```
+resolvers += "jcenter" at "https://jcenter.bintray.com/"
+libraryDependencies += "com.github.thangiee" %% "scala-frp" % "1.2"
+```
 
 ###Example Usage
 

--- a/src/main/scala/io/dylemma/frp/EventJoin.scala
+++ b/src/main/scala/io/dylemma/frp/EventJoin.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean
   *
   * To create an EventJoin, implement the three required methods:
   * {{{
-  * protected def leftPparent: EventStream[A]
+  * protected def leftParent: EventStream[A]
   * protected def rightParent: EventStream[B]
   * protected def handle(event: Either[Event[A], Event[B]]): Boolean
   * }}}
@@ -68,7 +68,7 @@ trait EventJoin[A, B, C] extends EventSource[C] {
 
 	if (parentsStopped) {
 		// if both parents are stopped, automatically stop this and skip the handler setup
-		stop
+		stop()
 	} else {
 		//wrap leftParent's events in a Left
 		leftParent addHandler leftHandlerFunc

--- a/src/main/scala/io/dylemma/frp/EventPipe.scala
+++ b/src/main/scala/io/dylemma/frp/EventPipe.scala
@@ -42,7 +42,7 @@ trait EventPipe[A, B] extends EventSource[B] {
 
 	if (parent.stopped) {
 		// if the parent is stopped, then so should this
-		stop
+		stop()
 	} else {
 		// automatically attach the handler to the parent
 		parent addHandler handleFunc

--- a/src/main/scala/io/dylemma/frp/EventSource.scala
+++ b/src/main/scala/io/dylemma/frp/EventSource.scala
@@ -27,7 +27,7 @@ trait EventSource[A] extends EventStream[A] with EventSourceImpl[A] {
 	private val _stopped = new AtomicBoolean(false)
 
 	def stopped: Boolean = _stopped.get
-	def stop: Unit = if (_stopped.compareAndSet(false, true)) produce(Stop)
+	def stop(): Unit = if (_stopped.compareAndSet(false, true)) produce(Stop)
 	def fire(event: A): Unit = {
 		if (stopped) throw new IllegalStateException("Cannot fire events from a stopped EventSource")
 		else produce(Fire(event))
@@ -63,19 +63,19 @@ trait EventSource[A] extends EventStream[A] with EventSourceImpl[A] {
 
 				//run the handler: if it returns false, count it as a dead reference
 				case handle if !handle(item) =>
-					ref.clear
+					ref.clear()
 					deadCount += 1
 				case _ =>
 			}
 		} finally {
 			//purge is considered expensive: only do it if there are a lot of dead refs
-			if (deadCount >= purgeThreshold) purge
+			if (deadCount >= purgeThreshold) purge()
 		}
 	}
 
 	/* Removes dead handler references */
-	private def purge = {
-		var deadRefs = refs.filter(_.get == null)
+	private def purge() = {
+		val deadRefs = refs.filter(_.get == null)
 		for (r <- deadRefs) refs -= r
 	}
 }

--- a/src/main/scala/io/dylemma/frp/EventSource.scala
+++ b/src/main/scala/io/dylemma/frp/EventSource.scala
@@ -26,6 +26,7 @@ object EventSource {
 trait EventSource[A] extends EventStream[A] with EventSourceImpl[A] {
 	private val _stopped = new AtomicBoolean(false)
 
+	def clear(): Unit = refs.clear()
 	def stopped: Boolean = _stopped.get
 	def stop(): Unit = if (_stopped.compareAndSet(false, true)) produce(Stop)
 	def fire(event: A): Unit = {

--- a/src/main/scala/io/dylemma/frp/EventStream.scala
+++ b/src/main/scala/io/dylemma/frp/EventStream.scala
@@ -83,6 +83,8 @@ trait EventStream[+A] {
 		addHandler(handler)
 	}
 
+	def clear(): Unit
+
 	/** Marks whether or not this stream is stopped. A stopped stream will not
 	  * produce any more events.
 	  * @return `true` if this stream is stopped, `false` otherwise.

--- a/src/main/scala/io/dylemma/frp/EventStream.scala
+++ b/src/main/scala/io/dylemma/frp/EventStream.scala
@@ -69,7 +69,7 @@ trait EventStream[+A] {
 	  * reference loops.
 	  */
 	def sink(handler: Event[A] => Boolean)(implicit obs: Observer): Unit = {
-		/* Keep a reference to both `this` and the `handler` in memory, via the 
+		/* Keep a reference to both `this` and the `handler` in memory, via the
 		 * implicit `Observer`. This way, neither can be garbage collected until
 		 * the `Observer` can.
 		 */
@@ -377,8 +377,8 @@ trait EventStream[+A] {
 object EventStream {
 	/** An EventStream that will never fire any events, and is currently `stopped`. */
 	val Nil: EventStream[Nothing] = {
-		val s = EventSource[Nothing]
-		s.stop
+		val s = EventSource[Nothing]()
+		s.stop()
 		s
 	}
 

--- a/src/main/scala/io/dylemma/frp/impl/EventSourceImpl.scala
+++ b/src/main/scala/io/dylemma/frp/impl/EventSourceImpl.scala
@@ -62,12 +62,9 @@ private[frp] trait EventSourceImpl[A] { self: EventSource[A] =>
 	}
 
 	def within(duration: Duration): EventStream[A] = duration match {
-		case d: FiniteDuration =>
-			new DeadlinedEventStream(this, Deadline.now + d)
-		case d if (d > Duration.Zero) => //infinite and positive
-			this
-		case _ =>
-			EventStream.Nil
+		case d: FiniteDuration      => new DeadlinedEventStream(this, Deadline.now + d)
+		case d if d > Duration.Zero => this //infinite and positive
+		case _                      => EventStream.Nil
 	}
 
 	def before(deadline: Deadline): EventStream[A] = {

--- a/src/test/scala/io/dylemma/frp/test/EventStreamDeadlineTests.scala
+++ b/src/test/scala/io/dylemma/frp/test/EventStreamDeadlineTests.scala
@@ -9,7 +9,7 @@ class EventStreamDeadlineTests extends FunSuite with TestHelpers with AsyncAsser
 
 	test("EventStream.before only encounters events before the deadline") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		w {
 			val x = s.before(100 millis fromNow)
 			val list = accumulateEvents(x)
@@ -26,7 +26,7 @@ class EventStreamDeadlineTests extends FunSuite with TestHelpers with AsyncAsser
 	}
 
 	test("EventStream.before `now` should accumulate no events") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s.before(Deadline.now)
 		val list = accumulateEvents(x)
 
@@ -39,7 +39,7 @@ class EventStreamDeadlineTests extends FunSuite with TestHelpers with AsyncAsser
 
 	test("EventStream.within only encounters events within the timespan") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		w {
 			val x = s.within(100.millis)
 			val list = accumulateEvents(x)
@@ -57,7 +57,7 @@ class EventStreamDeadlineTests extends FunSuite with TestHelpers with AsyncAsser
 
 	test("EventStream.within will encounter all events given an infinite duration") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		w {
 			val x = s.within(Duration.Inf)
 			val list = accumulateEvents(x)

--- a/src/test/scala/io/dylemma/frp/test/EventStreamFuturesTest.scala
+++ b/src/test/scala/io/dylemma/frp/test/EventStreamFuturesTest.scala
@@ -12,7 +12,7 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.next completes successfully when the stream fires an event") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.next onSuccess { case 5 => w.dismiss }
 		s fire 5
@@ -21,25 +21,25 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.next completes with a failure when called on a stopped stream") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
-		s.stop // stream stopped before `next` is called
+		s.stop() // stream stopped before `next` is called
 		s.next onFailure { case _ => w.dismiss }
 		w.await(dismissals(1))
 	}
 
 	test("EventStream.next completes with a failure if the stream stops before firing an event") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.next onFailure { case _ => w.dismiss }
-		s.stop // stream stopped after `next` is called
+		s.stop() // stream stopped after `next` is called
 		w.await(dismissals(1))
 	}
 
 	test("EventStream.next never completes if the stream does nothing") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		//this block should never actually run
 		s.next onComplete {
@@ -56,20 +56,20 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.last completes successfully with the last event fired by the stream") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.last onSuccess { case 3 => w.dismiss }
 		s fire 1
 		s fire 2
 		s fire 3
-		s.stop
+		s.stop()
 
 		w.await(dismissals(1))
 	}
 
 	test("EventStream.last should never complete if the stream never stops") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.last onSuccess { case 3 => w.dismiss }
 		s fire 1
@@ -84,8 +84,8 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.last should be a failure when called on a stopped stream") {
 		val w = new Waiter
-		val s = EventSource[Int]
-		s.stop
+		val s = EventSource[Int]()
+		s.stop()
 
 		s.last onFailure { case _ => w.dismiss }
 		w.await(dismissals(1))
@@ -93,17 +93,17 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.last should be a failure if the stream stops before firing an event") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.last onFailure { case _ => w.dismiss }
-		s.stop
+		s.stop()
 		w.await(dismissals(1))
 	}
 
 	test("EventStream.end completes successfully when called on a stopped stream") {
 		val w = new Waiter
-		val s = EventSource[Int]
-		s.stop
+		val s = EventSource[Int]()
+		s.stop()
 
 		s.end onSuccess { case _ => w.dismiss }
 		w.await(dismissals(1))
@@ -111,16 +111,16 @@ class EventStreamFuturesTest extends FunSuite with TestHelpers with AsyncAsserti
 
 	test("EventStream.end completes successfully when the stream stops") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.end onSuccess { case _ => w.dismiss }
-		s.stop
+		s.stop()
 		w.await(dismissals(1))
 	}
 
 	test("EventStream.end never completes if the stream never stops") {
 		val w = new Waiter
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		s.end onComplete { _ => w.dismiss }
 		//not stopping s...

--- a/src/test/scala/io/dylemma/frp/test/EventStreamSinkTests.scala
+++ b/src/test/scala/io/dylemma/frp/test/EventStreamSinkTests.scala
@@ -7,7 +7,7 @@ import collection.mutable.ListBuffer
 class EventStreamSinkTests extends FunSuite with Observer {
 
 	test("EventStream.onNext encounters *only* the next event") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val ints = new ListBuffer[Int]
 		s onNext { ints += _ }
 
@@ -18,7 +18,7 @@ class EventStreamSinkTests extends FunSuite with Observer {
 	}
 
 	test("EventStream.onEnd not triggered when `stop` not called") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		var gotEnd = false
 		s onEnd { gotEnd = true }
 
@@ -29,19 +29,19 @@ class EventStreamSinkTests extends FunSuite with Observer {
 	}
 
 	test("EventStream.onEnd triggered when `stop` called") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		var gotEnd = false
 		s onEnd { gotEnd = true }
 
 		s fire 1
 		s fire 2
-		s.stop
+		s.stop()
 
 		assert(gotEnd)
 	}
 
 	test("EventStream.foreach encounters all `fire`d events") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val ints = new ListBuffer[Int]
 		s foreach { ints += _ }
 

--- a/src/test/scala/io/dylemma/frp/test/EventStreamTests.scala
+++ b/src/test/scala/io/dylemma/frp/test/EventStreamTests.scala
@@ -8,7 +8,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	implicit object observer extends Observer
 
 	test("EventStream.map basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 
 		val results = accumulateEvents(s.map { _ * 2 })
 
@@ -20,8 +20,8 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.withFilter basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		val x = for {
 			i <- s if i % 2 == 0
 			j <- t
@@ -39,11 +39,11 @@ class EventStreamTests extends FunSuite with TestHelpers {
 		t fire 3 // yields 4 -> 3
 		t fire 4 // yields 4 -> 4
 
-		assert(results == List(2 -> 1, 2 -> 2, 4 -> 3, 4 -> 4))
+		assert(results.toList == List(2 -> 1, 2 -> 2, 4 -> 3, 4 -> 4))
 	}
 
 	test("EventStream.collect basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s collect {
 			case i if i % 2 == 0 => i / 2
 		}
@@ -54,11 +54,11 @@ class EventStreamTests extends FunSuite with TestHelpers {
 		s fire 3
 		s fire 4 // yield 2
 
-		assert(results == List(1, 2))
+		assert(results.toList == List(1, 2))
 	}
 
 	test("EventStream.foldLeft basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s.foldLeft(0) { _ + _ } //accumulate a sum
 		val results = accumulateEvents(x)
 
@@ -67,11 +67,11 @@ class EventStreamTests extends FunSuite with TestHelpers {
 		s fire 3 // yield 6
 		s fire 4 // yield 10
 
-		assert(results == List(1, 3, 6, 10))
+		assert(results.toList == List(1, 3, 6, 10))
 	}
 
 	test("EventStream.take basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s.take(3)
 
 		val results = accumulateEvents(x)
@@ -90,7 +90,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.takeWhile basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s takeWhile { _ < 4 }
 		val results = accumulateEvents(x)
 		val gotEnd = awaitStop(x)
@@ -102,7 +102,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.dropWhile basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s dropWhile { _ < 3 }
 		val results = accumulateEvents(x)
 
@@ -116,7 +116,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.drop basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s drop 3
 		val results = accumulateEvents(x)
 
@@ -126,14 +126,14 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.++ basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		val results = accumulateEvents(s ++ t)
 
 		s fire 1
 		t fire 2 //ignored because s isn't done
 		s fire 3
-		s.stop
+		s.stop()
 		t fire 4
 		t fire 5
 
@@ -141,23 +141,23 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.++ encounters end when both parents end") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		var gotEnd = false
 
 		s ++ t onEnd { gotEnd = true }
 
 		s fire 1
-		s.stop
+		s.stop()
 		t fire 2
-		t.stop
+		t.stop()
 
 		assert(gotEnd)
 	}
 
 	test("EventStream.until basic functionality") {
-		val s = EventSource[Int]
-		val end = EventSource[String]
+		val s = EventSource[Int]()
+		val end = EventSource[String]()
 		val results = accumulateEvents(s until end)
 
 		s fire 1
@@ -171,8 +171,8 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.|| basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		val results = accumulateEvents(s || t)
 
 		s fire 1
@@ -184,8 +184,8 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.either basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[String]
+		val s = EventSource[Int]()
+		val t = EventSource[String]()
 		val results = accumulateEvents(s either t)
 
 		s fire 1
@@ -197,7 +197,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.zipWithIndex basic functionality") {
-		val s = EventSource[Char]
+		val s = EventSource[Char]()
 		val results = accumulateEvents(s.zipWithIndex)
 
 		s fire 'a'
@@ -208,7 +208,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.zipWithStaleness basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val x = s.zipWithStaleness
 
 		var a: (Int, () => Boolean) = null
@@ -230,11 +230,11 @@ class EventStreamTests extends FunSuite with TestHelpers {
 
 		assert(a._2(), "The first event should be stale")
 		assert(b._2(), "The second event should be stale")
-		assert(!c._2(), "The thrid event should be fresh")
+		assert(!c._2(), "The third event should be fresh")
 	}
 
 	test("EventStream.zipWithTime basic functionality") {
-		val s = EventSource[Int]
+		val s = EventSource[Int]()
 		val fakeTime = new FakeTime
 
 		//use fakeTime instead of SystemTime, so we can guarantee the values
@@ -255,8 +255,8 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.zip basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[String]
+		val s = EventSource[Int]()
+		val t = EventSource[String]()
 		val results = accumulateEvents(s zip t)
 
 		s fire 1
@@ -270,7 +270,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.unzip basic functionality") {
-		val x = EventSource[(Int, String)]
+		val x = EventSource[(Int, String)]()
 		val (a, b) = x.unzip
 
 		val aResults = accumulateEvents(a)
@@ -283,7 +283,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 	}
 
 	test("EventStream.grouped basic functionality") {
-		val x = EventSource[Int]
+		val x = EventSource[Int]()
 		val results = accumulateEvents(x grouped 3)
 
 		//group 1: (1,2,3)
@@ -298,7 +298,7 @@ class EventStreamTests extends FunSuite with TestHelpers {
 
 		//group 3: (7, <end>)
 		x fire 7
-		x.stop
+		x.stop()
 
 		assert(results.toList == List(1, 2, 3) :: List(4, 5, 6) :: List(7) :: Nil)
 	}

--- a/src/test/scala/io/dylemma/frp/test/EventStream_flatMap.scala
+++ b/src/test/scala/io/dylemma/frp/test/EventStream_flatMap.scala
@@ -6,8 +6,8 @@ import io.dylemma.frp._
 class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 
 	test("EventStream.flatMap basic functionality") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 
 		val x = for {
 			i <- s
@@ -29,9 +29,9 @@ class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 	}
 
 	test("EventStream.flatMap over multiple layers") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
-		val u = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
+		val u = EventSource[Int]()
 
 		val x = for {
 			i <- s
@@ -57,8 +57,8 @@ class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 	}
 
 	test("EventStream.flatMap encounters nothing when the second stream fires nothing") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 
 		val x = for {
 			i <- s
@@ -76,8 +76,8 @@ class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 	}
 
 	test("EventStream.flatMap does not end if the mapped stream ends") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		val x = for {
 			i <- s
 			j <- t
@@ -87,15 +87,15 @@ class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 
 		s fire 1
 		t fire 2
-		t.stop
+		t.stop()
 
 		assert(!stopped())
 		assert(results.toList == List(1 -> 2))
 	}
 
 	test("EventStream.flatMap ends when the base stream ends") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
 		val x = for {
 			i <- s
 			j <- t
@@ -106,15 +106,15 @@ class EventStream_flatMap extends FunSuite with TestHelpers with Observer {
 
 		s fire 1
 		t fire 2
-		s.stop
+		s.stop()
 		assert(stopped())
 		assert(results.toList == List(1 -> 2))
 	}
 
 	test("EventStream.flatMap on a stopped stream results in a stopped stream") {
-		val s = EventSource[Int]
-		val t = EventSource[Int]
-		s.stop
+		val s = EventSource[Int]()
+		val t = EventSource[Int]()
+		s.stop()
 
 		val x = for {
 			i <- s


### PR DESCRIPTION
Incorporates the code style changes and version updates from #4 and undoes some of the changes to the readme style and publishing settings.

The main changes in this are to:
 - publish builds for scala 2.11 (in addition to 2.10)
 - add `()` to many side-effecting methods that weren't there before